### PR TITLE
Fixed script input

### DIFF
--- a/Step 3/sample_fastq_file.pl
+++ b/Step 3/sample_fastq_file.pl
@@ -39,14 +39,14 @@ my $debug = 0;
 
 my $valid_seqs = 0;
 
-while (<IN>) {
+while (<STDIN>) {
 
         $debug and sleep(1);
 
         $header = $_;
-        $seq = <IN>;
-        $mid = <IN>;
-        $quals = <IN>;
+        $seq = <STDIN>;
+        $mid = <STDIN>;
+        $quals = <STDIN>;
         unless ($quals) {
                 die "Ran out of data in the middle of a read\n";
         }


### PR DESCRIPTION
Running the script in the current state gives this error from perl:
```
readline() on unopened filehandle IN at sample_qfast_file.pl line 42.
````
This is because the ```open``` statement in the original script has been deleted which means IN is not a valid filehandle. The correct handle for reading from stdin is STDIN, which I have added in this commit.
