### PR TITLE
Add many more tests to extract_comp

### DIFF
--- a/examples/extract-comp/main.rs
+++ b/examples/extract-comp/main.rs
@@ -10,11 +10,7 @@ use std::fs::File;
 
 fn main() {
     let mut reader = io_utils::get_reader(&Some(PathBuf::from("examples/extract-comp/in.fastq")), false);
-
-    let mut file = match File::create(&PathBuf::from("examples/extract-comp/out.json")) {
-        Err(why) => panic!("Couldn't open output JSON file: {}", why),
-        Ok(file) => file,
-    };
+    let mut compressed_reader = io_utils::get_reader(&Some(PathBuf::from("examples/extract-comp/cin.fastq.gz")), true);
 
     let result = run_json(FASTQReader::new( SampleArgs {
         trimmed_length: Some(50),
@@ -22,6 +18,20 @@ fn main() {
         min_phred_score: 0,
         n_content: None,
     }, &mut reader));
+
+    let compressed_result = run_json(FASTQReader::new( SampleArgs {
+        trimmed_length: Some(50),
+        target_read_count: 10,
+        min_phred_score: 0,
+        n_content: None,
+    }, &mut compressed_reader));
+
+    assert_eq!(result, compressed_result);
+
+    let mut file = match File::create(&PathBuf::from("examples/extract-comp/out.json")) {
+        Err(why) => panic!("Couldn't open output JSON file: {}", why),
+        Ok(file) => file,
+    };
 
     match file.write_all(result.0.as_bytes()) {
         Err(why) => panic!("couldn't write to output JSON file: {}", why),

--- a/src/extract_comp.rs
+++ b/src/extract_comp.rs
@@ -82,7 +82,7 @@ AAAAANNNNN
 #[cfg(test)]
 mod test_runs {
     use super::*;
-    use crate::test_utils::*;
+    use crate::{BaseCompColBases, test_utils::*};
 
     #[test]
     fn test_json_run() {
@@ -122,7 +122,57 @@ mod test_runs {
         assert_eq!(seqs, 1);
     }
 
- 
+    #[test]
+    fn test_run () {
+        let reader = return_reader(
+br"@
+AACAA
++
+*****
+@
+AAGGA
++
+!!!!!
+@
+AACAA
++
+*****
+@
+TAGGA
++
+*****
+@
+TACAA
++
+*****
+@
+TAGGA
++
+*****
+@
+TACAA
++
+*****
+@
+CCCCC
++
+*****
+@
+NNNNN
++
+*****");
+
+        let args = SampleArgs {
+            target_read_count: 8,
+            min_phred_score: 1,
+            n_content: Some(1),
+            trimmed_length: Some(4)
+        };
+
+        let (res, num) = run_core(FASTQReader::new(args, reader));
+        assert_eq!(num, 7);
+        assert_eq!(res.lib[0].bases, BaseCompColBases {A: 28, T: 57, G: 0, C: 14, N: 0});
+    }
 }
 
 #[cfg(test)]
@@ -293,7 +343,7 @@ impl FASTQRead {
 
     fn check_read(&mut self, args: &SampleArgs) -> bool {
         let seq = FASTQRead::trim(&self.seq, args.trimmed_length);
-        let quals = FASTQRead::trim(&self.seq, args.trimmed_length);
+        let quals = FASTQRead::trim(&self.quals, args.trimmed_length);
 
         let (seq, quals) = if seq.is_err() || quals.is_err() {
             eprintln!("Read is too short, shorter than trim length.");

--- a/src/extract_comp.rs
+++ b/src/extract_comp.rs
@@ -9,6 +9,15 @@ mod test_check_read {
     use crate::test_utils::*;
 
     #[test]
+    fn test_check_colorspace() {
+        let mut read = FASTQRead::new(6);
+        let mut reader = return_reader(b"@\nAT1CGN\n+\n!!!!!!");
+        read.read_fastq(&mut reader);
+
+        assert!(read.check_colorspace("AT1CGN"))
+    }
+
+    #[test]
     fn test_count_n() {
         assert_eq!(FASTQRead::count_n("NNANNA"), 4)
     }
@@ -113,14 +122,7 @@ mod test_runs {
         assert_eq!(seqs, 1);
     }
 
-    #[test]
-    fn test_check_colorspace() {
-        let mut read = FASTQRead::new(6);
-        let mut reader = return_reader(b"@\nAT1CGN\n+\n!!!!!!");
-        read.read_fastq(&mut reader);
-
-        assert!(read.check_colorspace("AT1CGN"))
-    }
+ 
 }
 
 #[cfg(test)]

--- a/src/extract_comp.rs
+++ b/src/extract_comp.rs
@@ -296,7 +296,7 @@ impl FASTQRead {
         let quals = FASTQRead::trim(&self.seq, args.trimmed_length);
 
         let (seq, quals) = if seq.is_err() || quals.is_err() {
-            eprintln!("Read is too short, shorter than trim length.\n{:?}", (seq, quals));
+            eprintln!("Read is too short, shorter than trim length.");
             return false;
         } else {(seq.unwrap(), quals.unwrap())};
 

--- a/src/extract_comp.rs
+++ b/src/extract_comp.rs
@@ -4,7 +4,74 @@ use std::io::BufRead;
 use crate::BaseComp;
 
 #[cfg(test)]
-mod sample_fastq_tests {
+mod test_check_read {
+    use super::*;
+    use crate::test_utils::*;
+
+    #[test]
+    fn test_count_n() {
+        assert_eq!(FASTQRead::count_n("NNANNA"), 4)
+    }
+
+    #[test]
+    fn test_get_average_quality() {
+        assert_eq!(FASTQRead::get_average_quality("#{|}"), 68)
+    }
+
+    #[test]
+    fn test_check_read () {
+        let mut reader = return_reader(
+br"@
+AAAAANNNNN
++
+!!!!!!!!!!");
+        let mut f = FASTQRead::new(5);
+        f.read_fastq(&mut reader);
+
+        // case where read is trimmed
+        let args = SampleArgs {
+            target_read_count: 1,
+            min_phred_score: 0,
+            n_content: None,
+            trimmed_length: Some(5)
+        };
+
+        assert_eq!(f.check_read(&args), true);
+
+        // case where read is too short for trim length
+        let args = SampleArgs {
+            target_read_count: 1,
+            min_phred_score: 0,
+            n_content: None,
+            trimmed_length: Some(15)
+        };
+
+        assert_eq!(f.check_read(&args), false);
+
+        // case where too many N's
+        let args = SampleArgs {
+            target_read_count: 1,
+            min_phred_score: 0,
+            n_content: Some(1),
+            trimmed_length: None
+        };
+
+        assert_eq!(f.check_read(&args), false);
+
+        // case where quality too low
+        let args = SampleArgs {
+            target_read_count: 1,
+            min_phred_score: 50,
+            n_content: Some(1),
+            trimmed_length: None
+        };
+
+        assert_eq!(f.check_read(&args), false);
+    }
+}
+
+#[cfg(test)]
+mod test_runs {
     use super::*;
     use crate::test_utils::*;
 
@@ -54,19 +121,47 @@ mod sample_fastq_tests {
 
         assert!(read.check_colorspace("AT1CGN"))
     }
+}
+
+#[cfg(test)]
+mod test_fastqreader {
+    use super::*;
+    use crate::test_utils::*;
 
     #[test]
-    fn test_count_n() {
-        let mut read = FASTQRead::new(6);
-        let mut reader = return_reader(b"@\n\n+\n!!!!!!");
-        read.read_fastq(&mut reader);
+    fn test_skipping () {
+        // cases of:
+        // read too short
+        // too many N
+        // too low quality
+        // correct read
+        let reader = return_reader(
+br"@
+ACGT
++
+IIII
+@
+ACNNN
++
+IIIII
+@
+ACGTN
++
+!!!!!
+@
+ACGTN
++
+IIIII
+");
 
-        assert_eq!(FASTQRead::count_n("NNANNA"), 4)
-    }
-
-    #[test]
-    fn test_get_average_quality() {
-        assert_eq!(FASTQRead::get_average_quality("#{|}"), 68)
+        let mut freader = FASTQReader::new(SampleArgs {
+            target_read_count: 2,
+            min_phred_score: 1,
+            n_content: Some(2),
+            trimmed_length: Some(5)
+        }, reader);
+        
+        assert_eq!(freader.next(), Some("ACGTN".to_string()));
     }
 }
 


### PR DESCRIPTION
Previous Tarpaulin report:
```
|| Tested/Total Lines:
|| src/bin/extract_comp.rs: 0/9
|| src/bin/plot_comp.rs: 0/10
|| src/extract_comp.rs: 90/103
|| src/lib.rs: 84/106
|| src/plot_comp.rs: 41/98
|| 
65.95% coverage, 215/326 lines covered
```
Tarpaulin report:
```
|| Tested/Total Lines:
|| src/bin/extract_comp.rs: 0/9
|| src/bin/plot_comp.rs: 0/10 
|| src/extract_comp.rs: 120/123
|| src/lib.rs: 84/106
|| src/plot_comp.rs: 41/98
|| 
70.81% coverage, 245/346 lines covered
```